### PR TITLE
Invoke command with environment variables

### DIFF
--- a/src/Command/RunCommand.php
+++ b/src/Command/RunCommand.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace TomAtom\JobQueueBundle\Command;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Symfony\Component\Process\Process;
+use TomAtom\JobQueueBundle\Entity\Job;
+
+#[AsCommand(
+    name: 'jobqueue:run',
+    description: 'Run a job from the queue',
+)]
+class RunCommand extends Command
+{
+
+    public function __construct(private readonly EntityManagerInterface $entityManager)
+    {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this->addArgument('jobId', InputArgument::REQUIRED, 'The ID of the job to run');
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        // Command data from the job
+        $jobId = $input->getArgument('jobId');
+        $job = $this->entityManager->getRepository(Job::class)->findOneBy(['id' => $jobId]);
+        $commandName = $job->getCommand();
+        $params = $job->getCommandParams();
+        $command = 'php bin/console ' . $commandName;
+        if ($params !== null && $params !== [] && $params !== '') {
+            if (is_array($params)) {
+                $command .= ' ' . implode(' ', $params);
+            } else {
+                $command .= ' ' . $params;
+            }
+        }
+
+        // Start the process
+        $process = new Process(explode(' ', $command));
+        $process->setWorkingDirectory(dirname(__DIR__, 5));
+        $process->enableOutput();
+        $process->setTimeout(null);
+        $process->start();
+
+        // Update the job
+        $job->setStatus(Job::STATUS_RUNNING);
+        $job->setStartedAt(new \DateTimeImmutable());
+        $this->entityManager->persist($job);
+        $this->entityManager->flush();
+
+        // Wait for the process to finish and save the command buffer to the output
+        $process->wait(function ($type, $buffer) use ($job): void {
+            $job->setOutput($job->getOutput() . $buffer);
+            $this->entityManager->persist($job);
+            $this->entityManager->flush();
+        });
+
+        $job->setStatus($process->isSuccessful() ? Job::STATUS_COMPLETED : Job::STATUS_FAILED);
+        $job->setClosedAt(new \DateTimeImmutable());
+        $job->setRuntime($job->getStartedAt()->diff($job->getClosedAt()));
+
+        $this->entityManager->persist($job);
+        $this->entityManager->flush();
+        return Command::SUCCESS;
+    }
+}

--- a/src/Message/JobMessage.php
+++ b/src/Message/JobMessage.php
@@ -5,10 +5,12 @@ namespace TomAtom\JobQueueBundle\Message;
 class JobMessage
 {
     private int $jobId;
+    private array $envVars;
 
-    public function __construct(int $jobId)
+    public function __construct(int $jobId, array $envVars)
     {
         $this->jobId = $jobId;
+        $this->envVars = $envVars;
     }
 
     /**
@@ -17,5 +19,10 @@ class JobMessage
     public function getJobId(): int
     {
         return $this->jobId;
+    }
+
+    public function getEnvVars(): array
+    {
+        return $this->envVars;
     }
 }

--- a/src/MessageHandler/JobMessageHandler.php
+++ b/src/MessageHandler/JobMessageHandler.php
@@ -2,64 +2,24 @@
 
 namespace TomAtom\JobQueueBundle\MessageHandler;
 
-use DateTimeImmutable;
-use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
 use Symfony\Component\Process\Process;
-use TomAtom\JobQueueBundle\Entity\Job;
 use TomAtom\JobQueueBundle\Message\JobMessage;
 
 #[AsMessageHandler]
 class JobMessageHandler
 {
-    private EntityManagerInterface $entityManager;
-
-    public function __construct(EntityManagerInterface $entityManager)
-    {
-        $this->entityManager = $entityManager;
-    }
-
     public function __invoke(JobMessage $message): void
     {
         // Command data from the job
         $jobId = $message->getJobId();
-        $job = $this->entityManager->getRepository(Job::class)->findOneBy(['id' => $jobId]);
-        $commandName = $job->getCommand();
-        $params = $job->getCommandParams();
-        $command = 'php bin/console ' . $commandName;
-        if ($params !== null && $params !== [] && $params !== '') {
-            if (is_array($params)) {
-                $command .= ' ' . implode(' ', $params);
-            } else {
-                $command .= ' ' . $params;
-            }
-        }
 
-        // Start the process
+        $command = sprintf('php bin/console jobqueue:run %s', $jobId);
         $process = new Process(explode(' ', $command));
         $process->setWorkingDirectory(dirname(__DIR__, 5));
-        $process->enableOutput();
+        $process->setEnv($message->getEnvVars());
+        $process->disableOutput();
         $process->setTimeout(null);
-        $process->start();
-
-        // Update the job
-        $job->setStatus(Job::STATUS_RUNNING);
-        $job->setStartedAt(new DateTimeImmutable());
-        $this->entityManager->persist($job);
-        $this->entityManager->flush();
-
-        // Wait for the process to finish and save the command buffer to the output
-        $process->wait(function ($type, $buffer) use ($job): void {
-            $job->setOutput($job->getOutput() . $buffer);
-            $this->entityManager->persist($job);
-            $this->entityManager->flush();
-        });
-
-        $job->setStatus($process->isSuccessful() ? Job::STATUS_COMPLETED : Job::STATUS_FAILED);
-        $job->setClosedAt(new DateTimeImmutable());
-        $job->setRuntime($job->getStartedAt()->diff($job->getClosedAt()));
-
-        $this->entityManager->persist($job);
-        $this->entityManager->flush();
+        $process->run();
     }
 }

--- a/src/Service/CommandJobFactory.php
+++ b/src/Service/CommandJobFactory.php
@@ -30,12 +30,13 @@ class CommandJobFactory
      * @param array $params
      * @param int|null $entityId - Entity ID
      * @param string|null $entityClassName - Entity class name (self:class)
+     * @param array|null $envVars - Environment variables
      * @return Job
      * @throws CommandJobException
      * @throws ORMException
      * @throws OptimisticLockException
      */
-    public function createCommandJob(string $commandName, array $params, int $entityId = null, string $entityClassName = null): Job
+    public function createCommandJob(string $commandName, array $params, int $entityId = null, string $entityClassName = null, array $envVars = []): Job
     {
         // Check if the same exact job exists, throw exception if it does
         if ($this->entityManager->getRepository(Job::class)->isAlreadyCreated($commandName, $params)) {
@@ -54,7 +55,7 @@ class CommandJobFactory
         $this->entityManager->flush();
 
         // Dispatch the message to the message bus
-        $message = new JobMessage($job->getId());
+        $message = new JobMessage($job->getId(), $envVars);
         $this->messageBus->dispatch($message);
 
         // Return created job


### PR DESCRIPTION
Allow to override Symfony environment variables while executing a command.

This PR is introducing a 2nd parameter on the `JobMessage` class which holds any optional shell environment variable. The logic from the message handler is moved to a new command (`jobqueue:run`) to achieve the requirement.

The process flow is adjusted as following:
1. Consume the message in `JobMessageHandler`
  a. Extract `jobId` and `envVars` array from the message
1. Fork a new process for `jobqueue:run` command and inject `envVars` via `$process->setEnv()`  
1. `jobqueue:run` command fetched the details of the job, executes the command and finally updates the job in the DB.

Usage:
```php
$this->jobFactory->createCommandJob('app:test', ['--limit=1'], envVars: ['APP_ENV' => 'dev']);
```

The given command (`app:test`) is being executed by getting `APP_ENV` injected to the new Process.
Other example if eg. a different DATABASE_URL is passed to `app:test`, the command can interact with this database connection (a requirement in multi tenant applications).