### PR TITLE
Don't display Create Job if route isn't registered

### DIFF
--- a/src/Controller/JobController.php
+++ b/src/Controller/JobController.php
@@ -42,7 +42,8 @@ class JobController extends AbstractController
 
         return $this->render('@JobQueue/job/detail.html.twig', [
             'job' => $job,
-            'relatedEntity' => $entity
+            'relatedEntity' => $entity,
+            'commandRouteAvailable' => $this->isCommandControllerRouteAvailable(),
         ]);
     }
 
@@ -77,6 +78,17 @@ class JobController extends AbstractController
             'jobs' => $jobs,
             'relatedEntityId' => $id,
             'relatedEntity' => $entity,
+            'commandRouteAvailable' => $this->isCommandControllerRouteAvailable(),
         ]);
+    }
+
+    private function isCommandControllerRouteAvailable(): bool
+    {
+        try {
+            $this->generateUrl('command_schedule');
+            return true;
+        } catch (\Exception $e) {
+            return false;
+        }
     }
 }

--- a/templates/job/detail.html.twig
+++ b/templates/job/detail.html.twig
@@ -18,9 +18,11 @@
                class="btn btn-secondary" role="button">
                 {{ 'job.job_list'|trans }}
             </a>
+            {% if commandRouteAvailable %}
             <a href="{{ path('command') }}" class="btn btn-primary" role="button">
                 {{ 'job.create_job'|trans }}
             </a>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/templates/job/list.html.twig
+++ b/templates/job/list.html.twig
@@ -13,11 +13,13 @@
                 {% endif %}
             </h1>
         </div>
+        {% if commandRouteAvailable %}
         <div class="col-4 text-end">
             <a href="{{ path('command') }}" class="btn btn-primary" role="button">
                 {{ 'job.create_job'|trans }}
             </a>
         </div>
+        {% endif %}
     </div>
 {% endblock %}
 


### PR DESCRIPTION
The original instructions about the Routing registrations is
```yaml
job_queue:
  resource: "@JobQueueBundle/src/Controller/"
  type: attribute
```

But what about if the application does not want/need to expose the "Create Job" feature (`CommandController`), thus registers the routes for the JobController only.
```yaml
job_queue:
  resource: "@JobQueueBundle/src/Controller/JobController.php"
  type: attribute
```

This PR adds a route validation and pass the result to Twig to render or not the additional button on the Job List and Job Detail pages. Without this check, Twig trows an exception on `{{ path('command') }}` since the route does not exist. 